### PR TITLE
fix: improve performance

### DIFF
--- a/test.js
+++ b/test.js
@@ -303,6 +303,20 @@ describe('isGlob', function() {
       assert(isGlob('\\*(abc|xyz)/*(abc|xyz)'));
       assert(isGlob('\\+(abc|xyz)/+(abc|xyz)'));
     });
+
+    it('should be performant and not subject to ReDoS/exponential backtracking', function() {
+      if (!String.prototype.repeat) {
+        return;
+      }
+      // These will time out if the algorithm is inefficient.
+      isGlob('('.repeat(1e5));
+      isGlob('('.repeat(1e5), {strict: false});
+      isGlob('['.repeat(1e5));
+      isGlob('['.repeat(1e5), {strict: false});
+      isGlob('{'.repeat(1e5));
+      isGlob('{'.repeat(1e5), {strict: false});
+      isGlob('\\'.repeat(1e5));
+      isGlob('\\'.repeat(1e5), {strict: false});
+    });
   });
 });
-


### PR DESCRIPTION
Replacing the regular expressions with algorithmic equivalents
remediates performance issues.

There are no doubt further performance enhancements that can be made
to the code here, but this addresses the most critical. On my
container, the performance tests added in this commit took less than 1
second to run with the code changes here compared to around 40 seconds
using the current module code.

(I also happen to think the algorithms are easier to understand,
maintain, and debug in this form as well.)